### PR TITLE
fix (script): buidler* not builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "migrate": "truffle migrate --network bscTestnet --reset",
     "compile": "truffle compile --network bscTestnet",
-    "test": "npx builder test",
-    "coverage": "npx builder coverage"
+    "test": "npx buidler test",
+    "coverage": "npx buidler coverage"
   },
   "dependencies": {
     "@openzeppelin/test-helpers": "^0.5.6",


### PR DESCRIPTION
"buidler" is intentionally misspelled per the brand's witty galaxy brain. since this is a common error, the script executes anyway (though warns users), but it ultimately leads to a less elegant outcome.